### PR TITLE
Fix #168: update mr-pdf to 1.0.8 for images in PDF

### DIFF
--- a/convert-to-pdf.js
+++ b/convert-to-pdf.js
@@ -10,7 +10,7 @@ const serve = async () => {
   console.error(stderr);
 };
 const killPort = async () => {
-  const { stdout, stderr } = await execa(`npx`, ['kill-port', PORT]);
+  const { stdout, stderr } = await execa('npx', ['kill-port', PORT]);
   console.log(stdout);
   console.error(stderr);
   process.exit(0);

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
   },
   "devDependencies": {
     "execa": "^5.1.1",
-    "mr-pdf": "^1.0.7",
+    "mr-pdf": "^1.0.8",
     "wait-on": "^6.0.0",
     "husky": "^7.0.0",
-    "prettier": "^2.4.1",
+    "prettier": "2.5.1",
     "pretty-quick": "^3.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5864,10 +5864,10 @@ mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mr-pdf@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/mr-pdf/-/mr-pdf-1.0.7.tgz#dd697221746b5e47850c63ca516644f6d64190d8"
-  integrity sha512-kt0nBI/21IWe6J8sjlbdMYZcIetTU2odxe3i7+5dxY+mSnbocUfkhsRItOuveZMxcou0YD+d+JZXxIzFe8on9Q==
+mr-pdf@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/mr-pdf/-/mr-pdf-1.0.8.tgz#14be8f908a3c2a1a08cfc1c95f0f8bb83a0ae1cf"
+  integrity sha512-aP1vrtP+SrmNwjL9dNIpWsSlaPesON4G/8CFYkp+Yxazj9eCY6TzYvCkFpfL/u6xTaMaExPe6gb6L7KQReXVIA==
   dependencies:
     chalk "^3.0.0"
     commander "^4.1.1"
@@ -6795,10 +6795,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-bytes@^5.3.0:
   version "5.6.0"


### PR DESCRIPTION
This fixes #168, updating the https://www.npmjs.com/package/mr-pdf to 1.0.8 to pick up the fix for missing images in https://github.com/kohheepeace/mr-pdf/pull/36.

I've tested it locally, and images now load, though there are still some rough edges in how the images are shown in certain cases.  I think this is more to do with CSS that needs to be applied better.

I've also pinned prettier to 2.5.1 so that there isn't so much churn on styling changes.