### PR TITLE
Upate shell script to move pdf to static and the download link

### DIFF
--- a/convert-to-pdf.sh
+++ b/convert-to-pdf.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 npx mr-pdf --initialDocURLs="http://localhost:3000" --contentSelector="article" --paginationSelector=".pagination-nav__item--next > a" --excludeSelectors=".margin-vert--xl a,.theme-edit-this-page,.tocCollapsible_1PrD theme-doc-toc-mobile tocMobile_3Hoh,.tocCollapsibleButton_2O1e" --coverImage="https://download.logo.wine/logo/Seneca_College/Seneca_College-Logo.wine.png" --coverTitle="Introduction to C Programming" --outputPDFFilename "Introduction-to-C.pdf"
+mv "./Introduction-to-C.pdf" "./static"

--- a/convert-to-pdf.sh
+++ b/convert-to-pdf.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
-npx mr-pdf --initialDocURLs="http://localhost:3000" --contentSelector="article" --paginationSelector=".pagination-nav__item--next > a" --excludeSelectors=".margin-vert--xl a,.theme-edit-this-page,.tocCollapsible_1PrD theme-doc-toc-mobile tocMobile_3Hoh,.tocCollapsibleButton_2O1e" --coverImage="https://download.logo.wine/logo/Seneca_College/Seneca_College-Logo.wine.png" --coverTitle="Introduction to C Programming" --outputPDFFilename "Introduction-to-C.pdf"
-mv "./Introduction-to-C.pdf" "./static"
+npx mr-pdf --initialDocURLs="http://localhost:3000" --contentSelector="article" --paginationSelector=".pagination-nav__item--next > a" --excludeSelectors=".margin-vert--xl a,.theme-edit-this-page,.tocCollapsible_1PrD theme-doc-toc-mobile tocMobile_3Hoh,.tocCollapsibleButton_2O1e" --coverImage="https://download.logo.wine/logo/Seneca_College/Seneca_College-Logo.wine.png" --coverTitle="Introduction to C Programming" --outputPDFFilename "./static/Introduction-to-C.pdf"

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ module.exports = {
               html: `<a href='#' id='pwa-button' class='footer__link-item' hidden>Install as an App</a>`,
             },
             {
-              html: `<a href='https://intro2c.sdds.ca/Introduction-to-C.pdf' id='download-pdf' class='footer__link-item' download='Introduction-to-C.pdf'>Download Notes (PDF)</a>`,
+              html: `<a href='../Introduction-to-C.pdf' id='download-pdf' class='footer__link-item' download='Introduction-to-C.pdf'>Download Notes (PDF)</a>`,
             },
           ],
         },


### PR DESCRIPTION
This PR fixes #163. 
I added `mv` in shell script so that it can be moved during `yarn serve-convert`. 
Also the footer link is updated too. My test result looks good. 