### PR TITLE
Update docusaurus.config.js copyright to match LICENSE.md

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,7 +46,7 @@ module.exports = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Seneca College.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Chris Szalwinski and Seneca College.`,
     },
     prism: {
       theme: lightCodeTheme,


### PR DESCRIPTION
When I updated the copyright info in https://github.com/Seneca-ICTOER/Intro2C/issues/132, I made a mistake and missed that we also have the copyright in the site's footer.  I've corrected that here.

Apologies for missing this, it wasn't intentional.  I'd appreciate pointers to any other places where I've made this same mistake.  I can't see any, but I missed this one.